### PR TITLE
 Update YouTube Project Template Video

### DIFF
--- a/SideWaffleWebsite/index.cshtml
+++ b/SideWaffleWebsite/index.cshtml
@@ -77,7 +77,7 @@
                     <h3>Video tutorials</h3>
                     <ul>
                         <li><a href="http://youtu.be/naY3jbBNNgY">Item templates</a></li>
-                        <li><a href="http://youtu.be/NChUqnArTrI">Project templates</a></li>
+                        <li><a href="http://youtu.be/z33jOo75CH4">Project templates</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
The current link on the site points to an outdated video for project
templates. Updated the link to point to the one that uses template
builder